### PR TITLE
Enforce character limit from Azure API

### DIFF
--- a/wagtailtextanalysis/providers/azure_text_analytics.py
+++ b/wagtailtextanalysis/providers/azure_text_analytics.py
@@ -1,13 +1,33 @@
+import logging
+
 from django.conf import settings
 from django.utils.translation import get_language
 import requests
+
+logger = logging.getLogger(__name__)
+
+# Characters limit:
+# https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/overview#data-limits
+AZURE_CHARACTER_LIMIT = 5120
+
+
+def prepare_text(text):
+    if len(text) > AZURE_CHARACTER_LIMIT:
+        logger.debug(
+            'The content had to be shortened to %d characters due to Azure '
+            'limitation.', AZURE_CHARACTER_LIMIT
+        )
+        return text[:AZURE_CHARACTER_LIMIT]
+    return text
 
 
 def get_sentiment(text, identifier):
     lang_and_country_code = get_language()
     lang_code = lang_and_country_code.split("-")[0]
 
-    json_data = {"documents": [{"id": identifier, "language": lang_code, "text": text}]}
+    json_data = {"documents": [{
+        "id": identifier, "language": lang_code, "text": prepare_text(text)
+    }]}
 
     json_response = get_sentiment_impl(json_data)
     documents = json_response["documents"]
@@ -37,7 +57,9 @@ def get_key_phrases(text, identifier):
     lang_and_country_code = get_language()
     lang_code = lang_and_country_code.split("-")[0]
 
-    json_data = {"documents": [{"id": identifier, "language": lang_code, "text": text}]}
+    json_data = {"documents": [{
+        "id": identifier, "language": lang_code, "text": prepare_text(text)
+    }]}
 
     json_response = get_key_phrases_impl(json_data)
     documents = json_response["documents"]


### PR DESCRIPTION
Currently longer documents will just return an empty list of key phrases or sentiment equal to 0 without failing.